### PR TITLE
Use binary engine

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,6 +4,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["orderByNulls"]
+  engineType = "binary"
 }
 
 datasource db {


### PR DESCRIPTION
A workaround for OpenSSL issues on Debian Docker images that fixes #74.

Makes Prisma use the legacy binary engine for queries instead of the new library engine.

# Pull Request Template

## Description

Makes Prisma use the old binary engine for queries

Fixes #74 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
