### PR TITLE
fix: remove fixed height on app shell

### DIFF
--- a/src/pages/manga/[id].tsx
+++ b/src/pages/manga/[id].tsx
@@ -28,7 +28,7 @@ export default function MangaPage() {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 88px)' }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ flexBasis: 'fit-content' }}>
         <MangaDetail manga={mangaQuery.data} />
       </Box>


### PR DESCRIPTION
# Pull Request Template

## Description

The fixed height on the app shell means the chapter list table doesn't work too well on smaller screens, you can end up with just a single row in the table. This PR removes the set height.

Quick recording showing before and after:

https://github.com/oae/kaizoku/assets/219017/457b8b6c-6e79-4525-8181-419259835efc

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
